### PR TITLE
Ported webhooks and changed the formatting to fit the new layout

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/che-incubator/che-workspace-operator/pkg/apis"
 	"github.com/che-incubator/che-workspace-operator/pkg/controller"
+	"github.com/che-incubator/che-workspace-operator/pkg/webhook"
 	"github.com/che-incubator/che-workspace-operator/version"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
@@ -112,6 +113,12 @@ func main() {
 	// Setup all Controllers
 	if err := controller.AddToManager(mgr); err != nil {
 		log.Error(err, "")
+		os.Exit(1)
+	}
+
+	// Setup all webhooks
+	if err := webhook.SetUpWebhooks(mgr, ctx); err != nil {
+		log.Error(err, "unable to register webhooks to the manager")
 		os.Exit(1)
 	}
 

--- a/deploy/controller.yaml
+++ b/deploy/controller.yaml
@@ -31,3 +31,28 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "che-workspace-operator"
+          ports:
+            - name: webhook-server
+              containerPort: 8443
+          volumeMounts:
+            - name: webhook-tls-certs
+              mountPath: /tmp/k8s-webhook-server/serving-certs
+              readOnly: true
+      volumes:
+        - name: webhook-tls-certs
+          secret:
+            secretName: webhook-server-tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: che-workspace-controller
+  name: workspace-controller
+spec:
+  ports:
+    - targetPort: webhook-server
+      protocol: TCP
+      port: 443
+  selector:
+    name: che-workspace-operator

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: che-workspace-operator
@@ -18,6 +18,12 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
   - apps
   resources:
   - deployments
@@ -26,6 +32,22 @@ rules:
   - statefulsets
   verbs:
   - '*'
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - '*'
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  - routes/custom-host
+  verbs:
+  - create
+  - delete
+  - list
+  - watch
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -42,23 +64,22 @@ rules:
   verbs:
   - update
 - apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  - deployments
-  verbs:
-  - get
-- apiGroups:
   - workspace.che.eclipse.org
   resources:
   - '*'
-  - components
   - workspaceroutings
   verbs:
   - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+- apiGroups:
+    - admissionregistration.k8s.io
+  resources:
+    - mutatingwebhookconfigurations
+    - validatingwebhookconfigurations
+  verbs:
+    - '*'

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -1,11 +1,12 @@
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: che-workspace-operator
 subjects:
 - kind: ServiceAccount
   name: che-workspace-operator
+  namespace: che-workspace-controller
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: che-workspace-operator
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/webhook-server-certs/Dockerfile
+++ b/deploy/webhook-server-certs/Dockerfile
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2019-2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+# CA key pair generation job container
+FROM alpine
+
+RUN apk add --no-cache openssl
+COPY generate-cert.sh /generate-cert.sh
+RUN mkdir /ca && /generate-cert.sh /ca
+ENTRYPOINT ["sh", "-c"]

--- a/deploy/webhook-server-certs/deploy-webhook-server-certs.sh
+++ b/deploy/webhook-server-certs/deploy-webhook-server-certs.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+#
+# Copyright (c) 2019-2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+# Generate a (self-signed) CA certificate and a certificate and private key to be used by the webhook server.
+# The certificate will be issued for the Common Name (CN) of `workspace-controller.che-workspace-controller.svc`,
+# which is the cluster-internal DNS name for the service.
+#
+# NOTE: THIS SCRIPT EXISTS FOR TEST PURPOSES ONLY. DO NOT USE IT FOR YOUR PRODUCTION WORKLOADS.
+
+set -e
+
+echo "Generating new TLS certificates using docker"
+PROJECT_FOLDER=$(dirname "$0")/../..
+docker build --no-cache -t generate-webhook-server-certs:latest ${PROJECT_FOLDER}/deploy/webhook-server-certs
+
+TARGET_FOLDER=$PROJECT_FOLDER/build/_output/webhook-certs
+mkdir -p $TARGET_FOLDER
+
+echo "Copying generated TLS certificates from docker container"
+docker run --name 'webhook-certs' generate-webhook-server-certs:latest exit 0
+docker cp webhook-certs:ca/. ${TARGET_FOLDER}/
+docker rm 'webhook-certs'
+
+kubectl delete secret -n che-workspace-controller webhook-server-tls --ignore-not-found=true
+kubectl -n che-workspace-controller create secret tls webhook-server-tls \
+    --cert "$TARGET_FOLDER/webhook-server-tls.crt" \
+    --key "$TARGET_FOLDER/webhook-server-tls.key"
+CA_BASE_64_CONTENT="$(openssl base64 -A <"${TARGET_FOLDER}/ca.crt")"
+kubectl patch -n che-workspace-controller secret webhook-server-tls -p="{\"data\":{\"ca.crt\": \"${CA_BASE_64_CONTENT}\"}}"
+echo "TLS certificates are stored in 'che-workspace-controller' namespace in 'webhook-server-tls' secret"
+
+rm -r ${TARGET_FOLDER}

--- a/deploy/webhook-server-certs/generate-cert.sh
+++ b/deploy/webhook-server-certs/generate-cert.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+#
+# Copyright (c) 2019-2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+# Generate a (self-signed) CA certificate and a certificate and private key to be used by the webhook server.
+# The certificate will be issued for the Common Name (CN) of `workspace-controller.che-workspace-controller.svc`,
+# which is the cluster-internal DNS name for the service.
+#
+# NOTE: THIS SCRIPT EXISTS FOR TEST PURPOSES ONLY. DO NOT USE IT FOR YOUR PRODUCTION WORKLOADS.
+set -e
+
+: ${1?'missing key directory'}
+
+key_dir="$1"
+
+chmod 0700 "$key_dir"
+cd "$key_dir"
+
+# Generate the CA cert and private key
+openssl req -nodes -new -x509 -keyout ca.key -out ca.crt -days 1024 -subj "/CN=Admission Workspace Controller Webhook"
+# Generate the private key for the webhook server
+openssl genrsa -out webhook-server-tls.key 2048
+# Generate a Certificate Signing Request (CSR) for the private key, and sign it with the private key of the CA.
+openssl req -new -key webhook-server-tls.key -subj "/CN=workspace-controller.che-workspace-controller.svc" \
+    | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial -days 365 -out webhook-server-tls.crt

--- a/pkg/common/client_creator.go
+++ b/pkg/common/client_creator.go
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+package common
+
+import (
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+func CreateClient() (crclient.Client, error) {
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := crclient.New(cfg, crclient.Options{})
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -12,6 +12,8 @@
 
 package config
 
+import "k8s.io/api/admissionregistration/v1beta1"
+
 // Internal constants
 const (
 	//default URL for accessing Che Rest API Emulator from Workspace containers
@@ -50,10 +52,10 @@ const (
 )
 
 // Constants for che-rest-apis
-const(
+const (
 	// Attribute of Runtime Machine to mark source of the container.
 	RestApisContainerSourceAttribute = "source"
-	RestApisPluginMachineAttribute = "plugin"
+	RestApisPluginMachineAttribute   = "plugin"
 
 	// Mark containers applied to workspace with help recipe definition.
 	RestApisRecipeSourceContainerAttribute = "recipe"
@@ -83,5 +85,28 @@ const(
 
 	// Workspace command attributes that indicates with which component it is associated. */
 	ComponentAliasCommandAttribute = "componentAlias"
+)
 
+// constants for webhook
+const (
+	// The address that the webhook will host on
+	WebhookServerHost = "0.0.0.0"
+
+	// The port that the webhook will host on
+	WebhookServerPort = 8443
+
+	// The directory where the certificate can be found by the webhook server
+	WebhookServerCertDir = "/tmp/k8s-webhook-server/serving-certs"
+)
+
+// constants for webhook configuration
+const (
+	// The name of the workspace admission hook
+	MutateWebhookCfgName = "mutate-workspace-admission-hooks"
+
+	// The webhooks path on the server
+	MutateWebhookPath = "/mutate-workspaces"
+
+	// Policy on webhook failure
+	MutateWebhookFailurePolicy = v1beta1.Fail
 )

--- a/pkg/controller/ownerref/ownerref.go
+++ b/pkg/controller/ownerref/ownerref.go
@@ -1,0 +1,75 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+package ownerref
+
+import (
+	"context"
+
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var Log = logf.Log.WithName("ownerref")
+
+//FindControllerOwner returns OwnerReferent that owns controller process
+//it starts searching from the current pod and then resolves owners recursively
+//until object without owner is not found
+func FindControllerOwner(ctx context.Context, client crclient.Client) (*metav1.OwnerReference, error) {
+	ns, err := k8sutil.GetOperatorNamespace()
+	if err != nil {
+		return nil, err
+	}
+
+	// Get current Pod the operator is running in
+	pod, err := k8sutil.GetPod(ctx, client, ns)
+	if err != nil {
+		return nil, err
+	}
+	podOwnerRefs := metav1.NewControllerRef(pod, pod.GroupVersionKind())
+	// Get Owner that the Pod belongs to
+	ownerRef := metav1.GetControllerOf(pod)
+	finalOwnerRef, err := findFinalOwnerRef(ctx, client, ns, ownerRef)
+	if err != nil {
+		return nil, err
+	}
+	if finalOwnerRef != nil {
+		return finalOwnerRef, nil
+	}
+
+	// Default to returning Pod as the Owner
+	return podOwnerRefs, nil
+}
+
+// findFinalOwnerRef tries to locate the final controller/owner based on the owner reference provided.
+func findFinalOwnerRef(ctx context.Context, client crclient.Client, ns string, ownerRef *metav1.OwnerReference) (*metav1.OwnerReference, error) {
+	if ownerRef == nil {
+		return nil, nil
+	}
+
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion(ownerRef.APIVersion)
+	obj.SetKind(ownerRef.Kind)
+	err := client.Get(ctx, types.NamespacedName{Namespace: ns, Name: ownerRef.Name}, obj)
+	if err != nil {
+		return nil, err
+	}
+	newOwnerRef := metav1.GetControllerOf(obj)
+	if newOwnerRef != nil {
+		return findFinalOwnerRef(ctx, client, ns, newOwnerRef)
+	}
+
+	Log.V(1).Info("Pods owner found", "Kind", ownerRef.Kind, "Name", ownerRef.Name, "Namespace", ns)
+	return ownerRef, nil
+}

--- a/pkg/webhook/add_creator_webhooks.go
+++ b/pkg/webhook/add_creator_webhooks.go
@@ -1,0 +1,17 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+package webhook
+
+import "github.com/che-incubator/che-workspace-operator/pkg/webhook/creator"
+
+func init() {
+	configureWebhookTasks = append(configureWebhookTasks, creator.SetUp)
+}

--- a/pkg/webhook/creator/creator.go
+++ b/pkg/webhook/creator/creator.go
@@ -1,0 +1,80 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+package creator
+
+import (
+	"context"
+
+	"github.com/che-incubator/che-workspace-operator/pkg/common"
+	"github.com/che-incubator/che-workspace-operator/pkg/config"
+	"github.com/che-incubator/che-workspace-operator/pkg/controller/ownerref"
+	"k8s.io/api/admissionregistration/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+var log = logf.Log.WithName("webhook.creator")
+
+//SetUp set up mutate webhook that manager creator annotations for workspaces
+func SetUp(webhookServer *webhook.Server, ctx context.Context) error {
+	log.Info("Configuring creator mutating webhook")
+	client, err := common.CreateClient()
+	if err != nil {
+		return err
+	}
+
+	log.Info("Finished creating  the client")
+
+	mutateWebhookCfg := buildMutateWebhookCfg()
+	log.Info("Building the mutating config")
+
+	ownRef, err := ownerref.FindControllerOwner(ctx, client)
+	if err != nil {
+		return err
+	}
+
+	log.Info("Got controller owner")
+
+	//TODO For some reasons it's still possible to update reference by user
+	//TODO Investigate if we can block it. The same issue is valid for Deployment owner
+	mutateWebhookCfg.SetOwnerReferences([]metav1.OwnerReference{*ownRef})
+
+	log.Info("set owner references")
+
+	if err := client.Create(ctx, mutateWebhookCfg); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+		// Webhook Configuration already exists, we want to update it
+		// as we do not know if any fields might have changed.
+		existingCfg := &v1beta1.MutatingWebhookConfiguration{}
+		err := client.Get(ctx, types.NamespacedName{
+			Name:      mutateWebhookCfg.Name,
+			Namespace: mutateWebhookCfg.Namespace,
+		}, existingCfg)
+
+		mutateWebhookCfg.ResourceVersion = existingCfg.ResourceVersion
+		err = client.Update(ctx, mutateWebhookCfg)
+		if err != nil {
+			return err
+		}
+		log.Info("Updated creator mutating webhook configuration")
+	} else {
+		log.Info("Created creator mutating webhook configuration")
+	}
+
+	webhookServer.Register(config.MutateWebhookPath, &webhook.Admission{Handler: &WorkspaceAnnotator{}})
+	return nil
+}

--- a/pkg/webhook/creator/mutatingwebhook.go
+++ b/pkg/webhook/creator/mutatingwebhook.go
@@ -1,0 +1,125 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+package creator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/che-incubator/che-workspace-operator/pkg/apis/workspace/v1alpha1"
+	"github.com/che-incubator/che-workspace-operator/pkg/config"
+	"k8s.io/api/admission/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// WorkspaceAnnotator annotates Workspaces
+type WorkspaceAnnotator struct {
+	client  client.Client
+	decoder *admission.Decoder
+}
+
+// WorkspaceAnnotator adds an creator annotation to every incoming workspaces.
+func (a *WorkspaceAnnotator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	switch req.Operation {
+	case v1beta1.Create:
+		return a.handleCreate(ctx, req)
+	case v1beta1.Update:
+		return a.handleUpdate(ctx, req)
+	default:
+		return admission.Denied(fmt.Sprintf("This admission is not supposed to handle %s operation. Please revise configuration", req.Operation))
+	}
+}
+
+func (a *WorkspaceAnnotator) handleCreate(_ context.Context, req admission.Request) admission.Response {
+	wksp := &v1alpha1.Workspace{}
+
+	err := a.decoder.Decode(req, wksp)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	log.Info("Provision creator annotation", "workspaceId", wksp.Status.WorkspaceId, "creator", req.UserInfo.UID)
+
+	if wksp.Annotations == nil {
+		wksp.Annotations = map[string]string{}
+	}
+	wksp.Annotations[config.WorkspaceCreatorAnnotation] = req.UserInfo.UID
+
+	marshaledWksp, err := json.Marshal(wksp)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledWksp)
+}
+
+func (a *WorkspaceAnnotator) handleUpdate(ctx context.Context, req admission.Request) admission.Response {
+	newWksp := &v1alpha1.Workspace{}
+	oldWksp := &v1alpha1.Workspace{}
+
+	err := a.decoder.Decode(req, newWksp)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	err = a.decoder.DecodeRaw(req.OldObject, oldWksp)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+	oldCreator, found := oldWksp.Annotations[config.WorkspaceCreatorAnnotation]
+	if !found {
+		log.Info(fmt.Sprintf("WARN: Worskpace %s does not have creator annotation. It happens only for old "+
+			"workspaces or when mutating webhook is not configured properly", newWksp.ObjectMeta.UID))
+		return returnPatchedWithUser(req.Object.Raw, newWksp, req.UserInfo.UID)
+	}
+
+	newCreator, found := newWksp.Annotations[config.WorkspaceCreatorAnnotation]
+	if !found {
+		return returnPatchedWithUser(req.Object.Raw, newWksp, oldCreator)
+	}
+
+	if newCreator != oldCreator {
+		return admission.Denied(fmt.Sprintf("annotation %s is immutable and must have value: %q", config.WorkspaceCreatorAnnotation, oldCreator))
+	}
+
+	return admission.Allowed("new workspace has the same creator as old one")
+}
+
+func returnPatchedWithUser(original []byte, patchedWksp *v1alpha1.Workspace, creator string) admission.Response {
+	patchedWksp.Annotations[config.WorkspaceCreatorAnnotation] = creator
+
+	marshaledWksp, err := json.Marshal(patchedWksp)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+	return admission.PatchResponseFromRaw(original, marshaledWksp)
+}
+
+// WorkspaceAnnotator implements inject.Client.
+// A client will be automatically injected.
+
+// InjectClient injects the client.
+func (a *WorkspaceAnnotator) InjectClient(c client.Client) error {
+	a.client = c
+	return nil
+}
+
+// WorkspaceAnnotator implements admission.DecoderInjector.
+// A decoder will be automatically injected.
+
+// InjectDecoder injects the decoder.
+func (a *WorkspaceAnnotator) InjectDecoder(d *admission.Decoder) error {
+	a.decoder = d
+	return nil
+}

--- a/pkg/webhook/creator/mutatingwebhookcfg.go
+++ b/pkg/webhook/creator/mutatingwebhookcfg.go
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+package creator
+
+import (
+	"github.com/che-incubator/che-workspace-operator/pkg/config"
+	"github.com/che-incubator/che-workspace-operator/pkg/webhook/server"
+	"k8s.io/api/admissionregistration/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func buildMutateWebhookCfg() *v1beta1.MutatingWebhookConfiguration {
+	mutateWebhookFailurePolicy := config.MutateWebhookFailurePolicy
+	mutateWebhookPath := config.MutateWebhookPath
+	return &v1beta1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: config.MutateWebhookCfgName,
+		},
+		Webhooks: []v1beta1.MutatingWebhook{
+			{
+				Name:          "mutate-workspaces.che-workspace-controller.svc",
+				FailurePolicy: &mutateWebhookFailurePolicy,
+				ClientConfig: v1beta1.WebhookClientConfig{
+					Service: &v1beta1.ServiceReference{
+						Name:      "workspace-controller",
+						Namespace: "che-workspace-controller",
+						Path:      &mutateWebhookPath,
+					},
+					CABundle: server.CABundle,
+				},
+				Rules: []v1beta1.RuleWithOperations{
+					{
+						Operations: []v1beta1.OperationType{v1beta1.Create, v1beta1.Update},
+						Rule: v1beta1.Rule{
+							APIGroups:   []string{"workspace.che.eclipse.org"},
+							APIVersions: []string{"v1alpha1"},
+							Resources:   []string{"workspaces"},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -1,0 +1,63 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+package server
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/che-incubator/che-workspace-operator/internal/cluster"
+	"github.com/che-incubator/che-workspace-operator/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var log = logf.Log.WithName("webhook.server")
+
+// CABundle contains the contents of the ca cert
+var CABundle []byte
+
+// ConfigureWebhookServer sets up the webhook server if webhooks and certs are available
+func ConfigureWebhookServer(mgr manager.Manager) (bool, error) {
+	log.Info("Checking if webhook configuration is enabled")
+	enabled, err := cluster.IsWebhookConfigurationEnabled()
+	log.Info("Finished checking cluster")
+
+	if err != nil {
+		log.Info("ERROR: Could not evaluate if admission webhook configurations are available", "error", err)
+		return false, err
+	}
+
+	if !enabled {
+		log.Info("WARN: AdmissionWebhooks are not configured at your cluster." +
+			"    To make your workspaces more secure, please configuring them." +
+			"    Skipping setting up Webhook Server")
+		return false, nil
+	}
+
+	log.Info("Attempting to read CA cert")
+	CABundle, err = ioutil.ReadFile(config.WebhookServerCertDir + "/ca.crt")
+	if os.IsNotExist(err) {
+		log.Info("CA certificate is not found. Webhook server is not set up")
+		return false, nil
+	}
+	if err != nil {
+		log.Info("Recieved error when trying to read CA certificate")
+		return false, err
+	}
+
+	log.Info("Setting up webhook server")
+	mgr.GetWebhookServer().Port = config.WebhookServerPort
+	mgr.GetWebhookServer().Host = config.WebhookServerHost
+	mgr.GetWebhookServer().CertDir = config.WebhookServerCertDir
+
+	return true, nil
+}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -1,0 +1,50 @@
+//
+// Copyright (c) 2019-2020 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+package webhook
+
+import (
+	"context"
+
+	"github.com/che-incubator/che-workspace-operator/pkg/webhook/server"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+var log = logf.Log.WithName("webhook")
+
+// configureWebhookTasks is a list of functions to add set webhook up and add them to the Manager
+var configureWebhookTasks []func(*webhook.Server, context.Context) error
+
+// SetUpWebhooks sets up Webhook server and registers webhooks configurations
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
+func SetUpWebhooks(mgr manager.Manager, ctx context.Context) error {
+	log.Info("Attempting to configure webhook server")
+	success, err := server.ConfigureWebhookServer(mgr)
+	if !success {
+		if err != nil {
+			log.Info("Failed to configure webhook server")
+			return err
+		} else {
+			log.Info("Webhook server is not set up. Skipping webhook cfg registration")
+		}
+	}
+
+	for _, f := range configureWebhookTasks {
+		if err := f(mgr.GetWebhookServer(), ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
#### What it does
This PR ports webhooks from master to this repo. The code is kept almost the exact same except for:
- constants extracted
- common method that was shared with embedded registry in upstream was extracted to its own file

#### Why the yaml files changed
A few things in the yaml files had to be converted back to their values in master so that webhooks would be able to be created:
1. Role -> ClusterRole, without cluster role trying to set up the webhooks will give:
```
mutatingwebhookconfigurations.admissionregistration.k8s.io is forbidden: User \"system:serviceaccount:che-workspace-controller:che-workspace-operator\" cannot create resource \"mutatingwebhookconfigurations\" in API group \"admissionregistration.k8s.io\" at the cluster scope
```
2. Additional rules from upstream needed to be added in order for webhooks to be created

#### Some unknown errors
It seems like theres a constant error log that happens after the webhook setup is done, though i'm not sure where these errors are coming from:

```
E0319 12:14:41.595900       1 reflector.go:125] pkg/mod/k8s.io/client-go@v0.0.0-20190918200256-06eb1244587a/tools/cache/reflector.go:98: Failed to list *unstructured.Unstructured: resourcequotas is forbidden: User "system:serviceaccount:che-workspace-controller:che-workspace-operator" cannot list resource "resourcequotas" in API group "" in the namespace "che-workspace-controller"
E0319 12:14:41.768928       1 reflector.go:125] pkg/mod/k8s.io/client-go@v0.0.0-20190918200256-06eb1244587a/tools/cache/reflector.go:98: Failed to list *unstructured.Unstructured: pods "proxy" not found
E0319 12:14:41.911261       1 reflector.go:125] pkg/mod/k8s.io/client-go@v0.0.0-20190918200256-06eb1244587a/tools/cache/reflector.go:98: Failed to list *unstructured.Unstructured: brokertemplateinstances.template.openshift.io is forbidden: User "system:serviceaccount:che-workspace-controller:che-workspace-operator" cannot list resource "brokertemplateinstances" in API group "template.openshift.io" in the namespace "che-workspace-controller"
E0319 12:14:41.911880       1 reflector.go:125] pkg/mod/k8s.io/client-go@v0.0.0-20190918200256-06eb1244587a/tools/cache/reflector.go:98: Failed to list *unstructured.Unstructured: bindings is forbidden: User "system:serviceaccount:che-workspace-controller:che-workspace-operator" cannot list resource "bindings" in API group "" in the namespace "che-workspace-controller"
```

though even if I comment out the webhook set up I still get similiar errors @amisevsk is this something you've seen?

Also trying to create a workspace I get:
```
{"level":"info","ts":1584625068.9276242,"logger":"controller_workspace","msg":"Reconciling Workspace","Request.Namespace":"che-workspace-controller","Request.Name":"cloud-shell"}
E0319 13:37:48.983054       1 reflector.go:125] pkg/mod/k8s.io/client-go@v0.0.0-20190918200256-06eb1244587a/tools/cache/reflector.go:98: Failed to list *unstructured.Unstructured: processedtemplates.template.openshift.io is forbidden: User "system:serviceaccount:che-workspace-controller:che-workspace-operator" cannot list resource "processedtemplates" in API group "template.openshift.io" in the namespace "che-workspace-controller"
{"level":"info","ts":1584625069.0292437,"logger":"controller_workspace","msg":"    => Creating v1.PersistentVolumeClaim","Request.Namespace":"che-workspace-controller","Request.Name":"cloud-shell","namespace":"che-workspace-controller","name":"claim-che-workspace"}
E0319 13:37:49.103655       1 reflector.go:125] pkg/mod/k8s.io/client-go@v0.0.0-20190918200256-06eb1244587a/tools/cache/reflector.go:98: Failed to list *v1.Role: roles.rbac.authorization.k8s.io is forbidden: User "system:serviceaccount:che-workspace-controller:che-workspace-operator" cannot list resource "roles" in API group "rbac.authorization.k8s.io" in the namespace "che-workspace-controller"
```

though its not exactly clear whether those errors being printed are continuing from before or not
